### PR TITLE
Remove abandoned entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,17 @@ project you agree to abide by its terms.
 
 Before sending a pull request, make sure that:
 
+- if the entry is a software, it should be maintained (at least a commit / a
+  release in the past 3 years),
 - the contents are sorted alphabetically,
-- the tests pass:
+- the tests pass (either on the CI or locally),
 
-  ```bash
-  gem install awesome_bot
-  awesome_bot README.md
-  ```
+      # using ruby
+      gem install awesome_bot
+      awesome_bot README.md
+      # using node.js
+      npm install -g awesome-lint
+      awesome-lint README.md
 
 Thank you for your suggestions!
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 > [reStructuredText](http://docutils.sourceforge.net/docs/ref/rst/directives.html) and
 > [Jupyter notebooks](https://jupyter.readthedocs.io/en/latest/).
 
-:star: - means **really _awesome/useful_**.<br />
-:bookmark: - means ability to **seamlessly cite references**.<br/>
-:link: - means ability to **cross-reference figures and sections within the
+:star: means **really _awesome/useful_**.<br />
+:bookmark: means ability to **seamlessly cite references**.<br/>
+:link: means ability to **cross-reference figures and sections within the
 document**.<br/>
 **Σ** means ability to **write equations in LaTeX**.<br/>
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ document**.<br/>
 - [pandoc](https://pandoc.org/MANUAL) - A Haskell library for converting from
    one markup format to another, and a command-line tool that uses this
    library :star: :bookmark: :link: **Σ**.
-- [scholdoc](http://scholdoc.scholarlymarkdown.com/) - A fork of Pandoc and the
-   reference implementation for ScholarlyMarkdown, a superset of Pandoc
-   Markdown flavour :bookmark: :link: **Σ**.
 
 ## Demos
  Demos can include working examples, tutorials, videos demonstrating how to


### PR DESCRIPTION
Add guidelines for keeping maintained software.
Remove scholdoc from the converters section (abandoned?).

- [x] Table of contents has been updated (if needed).
- [x] Contents have been sorted alphabetically.
