### PR TITLE
docs: Fixing R Markdown entry emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ document**.
 - [Marktext](https://github.com/marktext/marktext) - Markdown text editor.
 - [R Studio](https://github.com/rstudio/rstudio) - IDE for R.
   - [bookdown](https://github.com/rstudio/bookdown) - R package to facilitate writing books and long-form articles, reports with R Markdown :bookmark: :link:.
-  - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown
-   :bookmark:
-   :link:.
+  - [R Markdown](https://rmarkdown.rstudio.com/) - R package to write R next to Markdown :bookmark: :link:.
 - [Vim](https://www.vim.org/) - Command line text editor.
   - [fzf-bibtex](https://github.com/msprev/fzf-bibtex/#readme) - BibTeX source
     with Vim integration which uses fzf (a fuzzy finder implemented in Go).


### PR DESCRIPTION
The emojis associated with RMarkdown are not rendering correctly in Github Flavored Markdown. This PR fixes that rendering issue.

**Editing R Markdown entry within Word Processing section**

<details>
  <summary>Short pitch</summary>

This change is solely fixing a display issue with the emojis within the README.

</details>

## Checklist


- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [-] If the entry is a software:
	- [-] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [-] it is **open-source** with appropriate **license**
- [-] Table of contents has been updated (if a section is added / removed).
- [-] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
