### PR TITLE
Add Plottie as an open-access scientific figure library

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ there are formal languages with which one can create beautiful graphics.
 - [graphviz](https://graphviz.org/) - Visualization software for graphs and
   networks which uses a domain-specific DOT language.
 - [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/) - Define simple diagrams instead of drawing them.
-- [Vega Lite](https://vega.github.io/vega-lite/examples/) - Define charts and more complex diagrams.
 - [PlantUML](https://plantuml.com/) - Define UML diagrams instead of drawing them.
+- [Plottie](https://plottie.art/) - Open-access reference library of scientific plots and figures for research and education.
+- [Vega Lite](https://vega.github.io/vega-lite/examples/) - Define charts and more complex diagrams.
 
 ## Converters and Filters
 


### PR DESCRIPTION
Added Plottie to the list of diagramming tools in the README.

Add  Plottie to the "Illustrations" section.

<details>
  <summary>Short pitch</summary>
Plottie is an open-access reference library of scientific plots and figures curated from peer-reviewed research.

It is useful as a reference resource for researchers, educators, and students who want to browse real-world examples of common scientific visualizations (e.g. heatmaps, scatter plots, line plots) rather than create diagrams from scratch.

</details>

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [ ] If the entry is a software:
	- [ ] it should be **maintained** (at least a commit / a release in the past 3 years),
	- [ ] it is **open-source** with appropriate **license**
- [ ] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->