### PR TITLE
Add CiteMe to Bibliography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Reference managers to generate citations, BibTeX, and BibLaTeX files.
 - [Citation Style Language (CSL) styles](https://editor.citationstyles.org/) - Crowdsourced
   repository with over 9000 free CSL citation styles and an online
   editor to create new ones.
+- [CiteMe](https://citeme.app/) - AI-powered citation generator that searches
+  11+ academic databases (OpenAlex, PubMed, Semantic Scholar, CrossRef, and more)
+  and formats in 43+ CSL citation styles. Available as a web app, browser
+  extension, and Google Docs add-on (free tier included).
 - [JabRef](https://www.jabref.org/) - Open source bibliography reference manager.
 - [Zotero](https://www.zotero.org/) - FOSS tool to collect, organize, cite, and
   share research.


### PR DESCRIPTION
## Short Pitch

[CiteMe](https://citeme.app/) is an AI-powered academic citation generator that searches 11+ databases (OpenAlex, PubMed, Semantic Scholar, CrossRef, CORE, Europe PMC, Springer, Google Books, and more) and formats references in 43+ CSL citation styles (APA, MLA, Chicago, Vancouver, ABNT, IEEE, Harvard, etc.).

It is available as:
- **Web app** at [citeme.app](https://citeme.app/)
- **Browser extension** for Chrome, Firefox, and Edge
- **Google Docs add-on**

CiteMe includes a free tier (20 citations/month) so anyone can use it at no cost.

### Why it fits this list

The Bibliography section currently lists reference managers and citation tools. CiteMe complements existing entries like Zotero and ZoteroBib by offering AI-powered search across multiple academic databases with instant CSL formatting — useful for researchers and students writing scientific papers.

### Checklist
- [x] One new entry per pull request
- [x] Entry is sorted alphabetically (between "Citation Style Language" and "JabRef")
- [x] Short pitch included in PR description
- [x] Table of contents unchanged (no section added/removed)