### PR TITLE
Add abnt-citation to Bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ document**.
 
 Reference managers to generate citations, BibTeX, and BibLaTeX files.
 
+- [abnt-citation](https://github.com/danielnichiata96/abnt-citation) - TypeScript library for formatting citations and parsing author names per Brazilian ABNT standards (NBR 6023:2025 and NBR 10520:2023).
 - [Citation Style Language (CSL) styles](https://editor.citationstyles.org/) - Crowdsourced
   repository with over 9000 free CSL citation styles and an online
   editor to create new ones.


### PR DESCRIPTION
## What

Adds [abnt-citation](https://github.com/danielnichiata96/abnt-citation) to the Bibliography section.

## Why it belongs

- **Only programmatic library for ABNT citation formatting** — all other entries in the Bibliography section are GUI apps or style repositories. `abnt-citation` is a TypeScript library that can be embedded in any application.
- **Open source (MIT), actively maintained, zero dependencies** — lightweight and easy to integrate.
- **Covers NBR 6023:2025 (references) and NBR 10520:2023 (in-text citations)** — the two core ABNT standards for academic citations in Brazil.
- **Brazilian Portuguese/Spanish name parsing** — handles compound surnames (e.g., "da Silva", "de los Santos"), acronym-protected institution names, and other edge cases unique to Lusophone/Hispanic academia.
- **Production-proven** — extracted from [CiteMe](https://citeme.app), a citation management platform used by thousands of students across Brazilian universities.

ABNT (Associação Brasileira de Normas Técnicas) is the mandatory citation standard for virtually all academic work in Brazil, the largest academic market in Latin America. This library fills a gap for developers building tools that serve this community.