### PR TITLE
Add docx-pipeline to Converters and Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Supplementary files and tools.
 - [docutils](https://docutils.sourceforge.io/docs/) - Python package which can
   convert reStructuredText into various formats and provides command-line
   tools to do it :link:.
+- [docx-pipeline](https://github.com/redamancy231-create/docx-pipeline) - Markdown to Chinese DOCX converter with dual backend (Pure Python + Pandoc) and Mermaid diagram support.
 - [Jupyter Book](https://jupyterbook.org/en/stable/) - A static site generator which converts
   a collection of CommonMark, MyST markdown and Jupyter notebooks into a HTML website.
 - [MyST](https://myst-parser.readthedocs.io/en/latest/) - Markedly Structured Text,


### PR DESCRIPTION
## Short pitch

[docx-pipeline](https://github.com/redamancy231-create/docx-pipeline) converts Markdown to production-quality Chinese DOCX files with a dual backend (Pure Python via python-docx + Pandoc subprocess). It includes automatic Mermaid diagram rendering and 4 preset templates. Unlike generic pandoc wrappers, it applies Chinese typography rules (fonts, indentation, heading colors) via post-processing.

### Criteria

- [x] Open-source with license: **MIT**
- [x] Maintained: v1.0.0 released (July 2026), active CI across Python 3.10–3.12 on Ubuntu/Windows/macOS
- [x] One entry added
- [x] Alphabetically sorted (between `docutils` and `Jupyter Book`)
- [x] Table of contents unchanged (no section added or removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)